### PR TITLE
Add dynamic commands using a function in task definition

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -6,15 +6,26 @@ const tasks = require('./tasks'),
       parseCommandLine = require('./utils').parseCommandLine,
       waitHttpPortReady = require('./utils').waitHttpPortReady,
       waitHttpPortAvailable = require('./utils').waitHttpPortAvailable,
-      EventEmitter = require("events").EventEmitter
+      EventEmitter = require("events").EventEmitter,
+      util = require('util')
 
 exports.run = (def) => {
-  if(def.sh) def.command = ['sh', '-c', def.sh]
-  let cmd = parseCommandLine(def.command)
+  if(def.sh) {
+    if(util.isFunction(def.sh)) {
+      def.command = (changedFiles) => ['sh', '-c', def.sh(changedFiles)]
+    } else {
+      def.command = ['sh', '-c', def.sh]
+    }
+  }
+  const dynamicCmd = util.isFunction(def.command)
+  let cmd = dynamicCmd ? [] : parseCommandLine(def.command)
   return tasks.create(
     def.name || def.sh || cmd.join(' '),
     def.cwd || __projectPath,
-    function(out, success, error) {
+    function(out, success, error, changedFiles) {
+      if(dynamicCmd) {
+        cmd = parseCommandLine(def.command(changedFiles))
+      }
       this.process = spawn(cmd[0], cmd.slice(1), {cwd: this.cwd, env: def.env || process.env})
       lineStream(this.process.stdout).on('line', (_, __, html) => out(html + '\n'))
       lineStream(this.process.stderr).on('line', (_, __, html) => out(html + '\n'))

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -22,8 +22,11 @@ exports.create = function(label, cwd, execute, kill, watch) {
     lastRun: undefined,
     buildBuffer: [],
     events: null,
+    changedFiles: [],
     execute(buildEvents) {
       __debug('[%s] Execute', this.id)
+      var changedFiles = this.changedFiles
+      this.changedFiles = []
       if(!this.running) {
         let start = Date.now()
         this.events = new EventEmitter()
@@ -49,7 +52,8 @@ exports.create = function(label, cwd, execute, kill, watch) {
               () => {
                 reject()
                 progress({task: this.id, state: 'error', ts: Date.now()})
-              }
+              },
+              changedFiles
             )
             __debug('[%s] Run', this.id)
           }
@@ -80,6 +84,7 @@ exports.create = function(label, cwd, execute, kill, watch) {
     },
     kill: function() {
       kill.call(this)
+      this.changedFiles = []
     },
     dirty: function() {
       __debug('[%s] Is dirty', this.id)

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -31,7 +31,12 @@ exports.watch = function(task, watchFiles) {
     )
     return (filename) => {
       for(let i=0; i<patterns.length; i++) {
-        if(filename && minimatch(filename, task.cwd == __projectPath ? patterns[i] : path.join(task.cwd, patterns[i]))) return true
+        if(filename && minimatch(filename, task.cwd == __projectPath ? patterns[i] : path.join(task.cwd, patterns[i]))) {
+          if(task.changedFiles && task.changedFiles.indexOf(filename) < 0) {
+            task.changedFiles.push(filename)
+          }
+          return true
+        }
       }
       return false
     }


### PR DESCRIPTION
Now you can define a `run` task like

``` javascript
let copyFiles = run({
  name: 'copy files',
  sh: (changedFiles) => `mkdir -p dist; cp ${changedFiles.join(' ')} dist/`,
  watch: ['src/**']
})
```

this can be pretty convenient to process only files that actually changed
