### PR TITLE
handling uncaughtExpection; fix on windows

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+examples/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.1.2](https://github.com/criteo/loop/tree/0.1.2) (2016-05-11)
+
+- Fix orphan processes issues on Linux.
+
 ## [0.1.1](https://github.com/criteo/loop/tree/0.1.1) (2016-04-22)
 
 - Add java example project.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# loop [![Build Status](https://travis-ci.org/criteo/loop.svg?branch=master)](https://travis-ci.org/criteo/loop)
-
+# loop
+[![Build Status](https://travis-ci.org/criteo/loop.svg?branch=master)](https://travis-ci.org/criteo/loop)
+[![npm version](https://badge.fury.io/js/devloop.svg)](https://badge.fury.io/js/devloop)
+[![Dependency Status](https://david-dm.org/criteo/loop.svg)](https://david-dm.org/criteo/loop)
 ## Awesome dev loop — enhance your web application development workflow
 
 - [Why?](#why)

--- a/lib/base.js
+++ b/lib/base.js
@@ -6,7 +6,8 @@ const tasks = require('./tasks'),
       parseCommandLine = require('./utils').parseCommandLine,
       waitHttpPortReady = require('./utils').waitHttpPortReady,
       waitHttpPortAvailable = require('./utils').waitHttpPortAvailable,
-      EventEmitter = require("events").EventEmitter
+      EventEmitter = require("events").EventEmitter,
+      os = require('os')
 
 exports.run = (def) => {
   if(def.sh) def.command = ['sh', '-c', def.sh]
@@ -37,7 +38,7 @@ exports.run = (def) => {
     },
     function() {
       if (this.process && !this.exited)
-        process.kill(-this.process.pid)
+        process.kill(os.platform() === 'win32' ? this.process.pid : -this.process.pid)
     },
     def.watch
   )
@@ -73,7 +74,6 @@ exports.runServer = (def) => {
             poller.cancel()
             error()
             this.dirty()
-            this.exited = true
           })
         } else {
           out('Address already in use, port ' + def.httpPort)
@@ -82,8 +82,8 @@ exports.runServer = (def) => {
       }, 5)
     },
     function() {
-      if (this.process && !this.exited)
-        process.kill(-this.process.pid)
+      if (this.process)
+        process.kill(os.platform() === 'win32' ? this.process.pid : -this.process.pid)
     },
     def.watch
   )

--- a/lib/term.js
+++ b/lib/term.js
@@ -32,4 +32,9 @@ exports.term = function(proxy) {
   })
 
   process.on('SIGINT', () => exit())
+  process.on('uncaughtException', err => {
+    terminal.red(`uncaughtException: ${err.message}\n`)
+    console.error(err.stack)
+    exit()
+  })
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
   "engines": {
     "node": ">=4.0.0"
   },
-  "license": "Apache 2.0"
+  "license": "Apache 2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/criteo/loop"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
   ],
   "dependencies": {
     "ansi_up": "1.3.x",
-    "babel-core": "6.3.x",
-    "babel-preset-es2015": "6.3.x",
-    "chokidar": "^1.4.3",
-    "http-proxy": "1.12.x",
+    "babel-core": "6.9.x",
+    "babel-preset-es2015": "6.9.x",
+    "chokidar": "^1.5.1",
+    "http-proxy": "1.13.x",
     "jquery": "~2.2.x",
     "minimatch": "3.0.x",
     "randomstring": "1.1.x",
-    "rx": "~4.0.x",
-    "stylus": "0.53.x",
-    "terminal-kit": "0.16.8"
+    "rx": "~4.1.x",
+    "stylus": "0.54.x",
+    "terminal-kit": "0.24.8"
   },
   "bin": {
     "loop": "bin/main.js"


### PR DESCRIPTION
- do some clean-up when an uncaughtExpection occurs, preventing dangling child processes
- exclude _**examples/**_ for distributed version on NPM
- bump some dependencies
- fix process killing issue on Windows
